### PR TITLE
Add a way to import packages into the database with a json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea/
 build/
 vendor/
 var/

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ module github.com/redds-be/rpkgm
 go 1.21
 
 require (
-	github.com/mattn/go-sqlite3 v1.14.20
+	github.com/mattn/go-sqlite3 v1.14.21
 	github.com/spf13/cobra v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/mattn/go-sqlite3 v1.14.20 h1:BAZ50Ns0OFBNxdAqFhbZqdPcht1Xlb16pDCqkq1spr0=
-github.com/mattn/go-sqlite3 v1.14.20/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mattn/go-sqlite3 v1.14.21 h1:IXocQLOykluc3xPE0Lvy8FtggMz1G+U3mEjg+0zGizc=
+github.com/mattn/go-sqlite3 v1.14.21/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -22,6 +22,19 @@ import (
 	_ "github.com/mattn/go-sqlite3" // Driver for sqlite
 )
 
+// Package defines a package in the database.
+type Package struct {
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	Version       string `json:"version"`
+	BuildFilesDir string `json:"buildFilesDir"`
+}
+
+// Packages defines a slice of package.
+type Packages struct {
+	Packages []Package `json:"packages"`
+}
+
 // PkgInfo defines the basic information about a give package.
 type PkgInfo struct {
 	Name             string
@@ -79,7 +92,15 @@ func (dbAdapter Adapter) CreatePkgTable() error {
 // AddToMainRepo adds a package to the package table in the repo.
 func (dbAdapter Adapter) AddToMainRepo(name, description, repoVersion, buildFilesDir string) error {
 	const queryString = `INSERT INTO packages VALUES ($1, $2, $3, $4, $5, $6);`
-	_, err := dbAdapter.dbase.Exec(queryString, name, description, repoVersion, "", false, buildFilesDir)
+	_, err := dbAdapter.dbase.Exec(
+		queryString,
+		name,
+		description,
+		repoVersion,
+		"",
+		false,
+		buildFilesDir,
+	)
 
 	return err
 }


### PR DESCRIPTION
Added two structs to define what's a package in json, rpgkm add doesn't require -n and -v anymore, add -i is used to import packages into the database.