### PR TITLE
Separate the subcommands logic into separate packages for each

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -39,6 +39,10 @@ linters-settings:
           - github.com/redds-be/rpkgm/internal/pkg
           - github.com/redds-be/rpkgm/internal/database
           - github.com/redds-be/rpkgm/internal/logging
+          - github.com/redds-be/rpkgm/internal/show
+          - github.com/redds-be/rpkgm/internal/manage
+          - github.com/redds-be/rpkgm/internal/add
+          - github.com/redds-be/rpkgm/internal/sync
           - github.com/spf13/cobra
           - github.com/google/uuid
           - github.com/mattn/go-sqlite3

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -17,13 +17,7 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"os"
-	"strings"
-
-	"github.com/redds-be/rpkgm/internal/database"
+	"github.com/redds-be/rpkgm/internal/add"
 	"github.com/redds-be/rpkgm/internal/util"
 	"github.com/spf13/cobra"
 )
@@ -46,127 +40,8 @@ var addCmd = &cobra.Command{
 		// Check if user is root.
 		util.CheckRoot()
 
-		// Connect to the database
-		dbAdapter, err := database.NewAdapter("sqlite3", repoDB)
-		if err != nil {
-			util.Display(os.Stderr, true, "rpkgm could not connect to the database. Error: %s", err)
-			os.Exit(1)
-		}
-
-		// Create the packages table if it does not exist
-		err = dbAdapter.CreatePkgTable()
-		if err != nil {
-			util.Display(
-				os.Stderr,
-				true,
-				"rpkgm could not create the packages table in the repo. Error: %s",
-				err,
-			)
-			os.Exit(1)
-		}
-
-		// If the user imports a file, add the packages described in it
-		if importFile != "" {
-			// Open the file to import
-			jsonPkgFile, err := os.Open(importFile)
-			if err != nil {
-				util.Display(os.Stderr, true, "rpkgm couldn't open the json file. Error: %s", err)
-				os.Exit(1)
-			}
-
-			// Read the file's content
-			contentInbytes, err := io.ReadAll(jsonPkgFile)
-			if err != nil {
-				util.Display(
-					os.Stderr, true,
-					"rpkgm couldn't read the json file's content. Error: %s",
-					err,
-				)
-				os.Exit(1)
-			}
-
-			// Initialize the Packages struct
-			var pkgs database.Packages
-
-			// Read the json content of the file
-			err = json.Unmarshal(contentInbytes, &pkgs)
-			if err != nil {
-				util.Display(os.Stderr, true, "rpkgm couldn't read the json file. Error: %s", err)
-				os.Exit(1)
-			}
-
-			// for every package in the json file, add it to the repo
-			for index := 0; index < len(pkgs.Packages); index++ {
-				// If there isn't a description, give one by default
-				if pkgs.Packages[index].Description == "" {
-					pkgs.Packages[index].Description = "[No description provided for this package.]"
-				}
-
-				// If there isn't a build files dir, give one by default
-				if pkgs.Packages[index].BuildFilesDir == "" {
-					pkgs.Packages[index].BuildFilesDir = fmt.Sprintf(
-						"var/rpkgm/main/%s",
-						pkgs.Packages[index].Name,
-					)
-				}
-
-				// Add the package to the repo
-				err = dbAdapter.AddToRepo(
-					pkgs.Packages[index].Name,
-					pkgs.Packages[index].Description,
-					pkgs.Packages[index].Version,
-					pkgs.Packages[index].BuildFilesDir,
-				)
-				if err != nil {
-					util.Display(
-						os.Stderr, true,
-						"rpkgm was unable to add %s to the repo. Error: %s",
-						pkgs.Packages[index].Name,
-						err,
-					)
-				}
-			}
-
-			// Close the json file
-			err = jsonPkgFile.Close()
-			if err != nil {
-				util.Display(os.Stderr, true, "rpgkm couln't close the json file. Error: %s", err)
-				os.Exit(1)
-			}
-		}
-
-		// If there's at least a name and a version, add the package
-		if name != "" && version != "" {
-			// Default value for buildFilesDir (doing it here instead of Flags() because I need 'name')
-			if buildFilesDir == "" {
-				buildFilesDir = fmt.Sprintf("var/rpkgm/main/%s", name)
-			}
-
-			// Remove any trailing /
-			buildFilesDir = strings.TrimSuffix(buildFilesDir, "/")
-
-			// Add the package to the main repo
-			err = dbAdapter.AddToRepo(name, description, version, buildFilesDir)
-			if err != nil {
-				util.Display(
-					os.Stderr, true,
-					"rpkgm could not add the package %s to the repo. Error: %s",
-					name, err,
-				)
-				os.Exit(1)
-			}
-		}
-
-		// Close the database connection
-		err = dbAdapter.CloseDBConnection()
-		if err != nil {
-			util.Display(
-				os.Stderr, true,
-				"rpkgm could not close the connection to the database. Error: %s",
-				err,
-			)
-			os.Exit(1)
-		}
+		// Decide what to do and do what is needed to do
+		add.Decide(repoDB, name, description, version, buildFilesDir, importFile)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ under certain conditions; see <https://www.gnu.org/licenses/gpl-3.0.html>.`,
 		} else {
 			err := cmd.Help()
 			if err != nil {
-				util.Display(os.Stderr, true, "rpkgm could not display the help message. Error: %s", err)
+				util.Display(os.Stderr, false, "rpkgm could not display the help message. Error: %s", err)
 			}
 		}
 	},
@@ -60,7 +60,7 @@ under certain conditions; see <https://www.gnu.org/licenses/gpl-3.0.html>.`,
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
-		util.Display(os.Stderr, true, "rpkgm could not start. Error: %s", err)
+		util.Display(os.Stderr, false, "rpkgm could not start. Error: %s", err)
 	}
 }
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -17,18 +17,15 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"os"
-
-	"github.com/redds-be/rpkgm/internal/database"
+	"github.com/redds-be/rpkgm/internal/sync"
 	"github.com/redds-be/rpkgm/internal/util"
 	"github.com/spf13/cobra"
 )
 
-var remote string
+var (
+	repoName string
+	remote   string
+)
 
 // syncCmd represents the sync command.
 var syncCmd = &cobra.Command{
@@ -38,221 +35,8 @@ var syncCmd = &cobra.Command{
 		// Check if user is root.
 		util.CheckRoot()
 
-		if importFile == "" {
-			destDir := fmt.Sprintf("var/rpkgm/%s", name)
-
-			err := os.MkdirAll(destDir, os.ModePerm)
-			if err != nil {
-				util.Display(
-					os.Stderr,
-					true,
-					"rpkgm could not create the destination directory for the build files.",
-				)
-				os.Exit(1)
-			}
-
-			archive := fmt.Sprintf("var/rpkgm/%s/%s.tar.gz", name, name)
-
-			err = util.Download(
-				archive,
-				fmt.Sprintf("https://%s/raw/main/%s.tar.gz", remote, name),
-			)
-			if err != nil {
-				util.Display(os.Stderr, true, "rpkgm could not download the build files.")
-				os.Exit(1)
-			}
-
-			importFile = fmt.Sprintf("var/rpkgm/%s/repo.json", name)
-
-			err = util.Download(
-				importFile,
-				fmt.Sprintf("https://%s/raw/main/repo.json", remote),
-			)
-			if err != nil {
-				util.Display(os.Stderr, true, "rpkgm could not download the JSON file of the repo.")
-				os.Exit(1)
-			}
-
-			err = util.Untar(destDir, archive)
-			if err != nil {
-				util.Display(
-					os.Stderr,
-					true,
-					"rpkgm could not untar the repo's archive. Error: %s",
-					err,
-				)
-				os.Exit(1)
-			}
-		}
-
-		// Open the file to import
-		jsonPkgFile, err := os.Open(importFile)
-		if err != nil {
-			util.Display(os.Stderr, true, "rpkgm couldn't open the json file. Error: %s", err)
-			os.Exit(1)
-		}
-
-		// Read the file's content
-		contentInbytes, err := io.ReadAll(jsonPkgFile)
-		if err != nil {
-			util.Display(
-				os.Stderr, true,
-				"rpkgm couldn't read the json file's content. Error: %s",
-				err,
-			)
-			os.Exit(1)
-		}
-
-		// Initialize the Packages struct
-		var pkgs database.Packages
-
-		// Read the json content of the file
-		err = json.Unmarshal(contentInbytes, &pkgs)
-		if err != nil {
-			util.Display(os.Stderr, true, "rpkgm couldn't read the json file. Error: %s", err)
-			os.Exit(1)
-		}
-
-		if _, err := os.Stat(repoDB); errors.Is(err, os.ErrNotExist) {
-			// Connect to the database
-			dbAdapter, err := database.NewAdapter("sqlite3", repoDB)
-			if err != nil {
-				util.Display(
-					os.Stderr,
-					true,
-					"rpkgm could not connect to the database. Error: %s",
-					err,
-				)
-				os.Exit(1)
-			}
-
-			// Create the packages table if it does not exist
-			err = dbAdapter.CreatePkgTable()
-			if err != nil {
-				util.Display(
-					os.Stderr,
-					true,
-					"rpkgm could not create the packages table in the repo. Error: %s",
-					err,
-				)
-				os.Exit(1)
-			}
-
-			// for every package in the json file, add it to the repo
-			for index := 0; index < len(pkgs.Packages); index++ {
-				// If there isn't a description, give one by default
-				if pkgs.Packages[index].Description == "" {
-					pkgs.Packages[index].Description = "[No description provided for this package.]"
-				}
-
-				// If there isn't a build files dir, give one by default
-				if pkgs.Packages[index].BuildFilesDir == "" {
-					pkgs.Packages[index].BuildFilesDir = fmt.Sprintf(
-						"var/rpkgm/main/%s",
-						pkgs.Packages[index].Name,
-					)
-				}
-
-				// Add the package to the repo
-				err = dbAdapter.AddToRepo(
-					pkgs.Packages[index].Name,
-					pkgs.Packages[index].Description,
-					pkgs.Packages[index].Version,
-					pkgs.Packages[index].BuildFilesDir,
-				)
-				if err != nil {
-					util.Display(
-						os.Stderr, true,
-						"rpkgm was unable to add %s to the repo. Error: %s",
-						pkgs.Packages[index].Name,
-						err,
-					)
-				}
-			}
-
-			// Close the database connection
-			err = dbAdapter.CloseDBConnection()
-			if err != nil {
-				util.Display(
-					os.Stderr, true,
-					"rpkgm could not close the connection to the database. Error: %s",
-					err,
-				)
-				os.Exit(1)
-			}
-		} else {
-			// Connect to the database
-			dbAdapter, err := database.NewAdapter("sqlite3", repoDB)
-			if err != nil {
-				util.Display(os.Stderr, true, "rpkgm could not connect to the database. Error: %s", err)
-				os.Exit(1)
-			}
-			// for every package in the json file, update their record
-			for index := 0; index < len(pkgs.Packages); index++ {
-				// Since UPDATE will set null strings as null in the database,
-				// we need to get the old information to avoid deleting some information if the JSON field is null.
-				pkgInfo, err := dbAdapter.GetPkgInfo(pkgs.Packages[index].Name)
-				if err != nil {
-					util.Display(
-						os.Stderr,
-						true,
-						"rpkgm was unable to get the information for the package %s to compare against new information. Error: %s",
-						pkgs.Packages[index].Name,
-						err,
-					)
-
-					continue
-				}
-
-				// If there isn't a description, give one by default
-				if pkgs.Packages[index].Description == "" {
-					pkgs.Packages[index].Description = pkgInfo.Description
-				}
-
-				// If there isn't a build files dir, give one by default
-				if pkgs.Packages[index].BuildFilesDir == "" {
-					pkgs.Packages[index].BuildFilesDir = pkgInfo.BuildFilesDir
-				}
-
-				if pkgs.Packages[index].Version == "" {
-					pkgs.Packages[index].Version = pkgInfo.RepoVersion
-				}
-
-				// Add the package to the repo
-				err = dbAdapter.SyncRepo(
-					pkgs.Packages[index].Name,
-					pkgs.Packages[index].Description,
-					pkgs.Packages[index].Version,
-					pkgs.Packages[index].BuildFilesDir,
-				)
-				if err != nil {
-					util.Display(
-						os.Stderr, true,
-						"rpkgm was unable to update %s in the repo. Error: %s",
-						pkgs.Packages[index].Name,
-						err,
-					)
-				}
-			}
-
-			// Close the database connection
-			err = dbAdapter.CloseDBConnection()
-			if err != nil {
-				util.Display(
-					os.Stderr, true,
-					"rpkgm could not close the connection to the database. Error: %s",
-					err,
-				)
-				os.Exit(1)
-			}
-		}
-
-		// Close the json file
-		err = jsonPkgFile.Close()
-		if err != nil {
-			util.Display(os.Stderr, true, "rpgkm couln't close the json file. Error: %s", err)
-			os.Exit(1)
-		}
+		// Decide what to do and do what is needed to do
+		sync.Decide(repoDB, importFile, remote, repoName)
 	},
 }
 
@@ -275,7 +59,7 @@ func init() { //nolint:gochecknoinits
 			"Specify a remote, only works with GitHub for now. (ex: github.com/<user>/<repo> without .git)")
 
 	// Flag for the repo's name
-	syncCmd.Flags().StringVarP(&name, "name", "n", "main", "Name of the repository.")
+	syncCmd.Flags().StringVarP(&repoName, "name", "n", "main", "Name of the repository.")
 
 	// If you use --remote, you should use --name
 	syncCmd.MarkFlagsRequiredTogether("remote", "name", "repo")

--- a/internal/add/add.go
+++ b/internal/add/add.go
@@ -1,0 +1,153 @@
+package add
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/redds-be/rpkgm/internal/database"
+	"github.com/redds-be/rpkgm/internal/util"
+)
+
+// importPkgs imports packages from a file to a repo.
+func ImportPkgs(importFile string, dbAdapter *database.Adapter) { //nolint:funlen
+	// Open the file to import
+	jsonPkgFile, err := os.Open(importFile)
+	if err != nil {
+		util.Display(os.Stderr, true, "rpkgm couldn't open the json file. Error: %s", err)
+		os.Exit(1)
+	}
+
+	// Read the file's content
+	contentInbytes, err := io.ReadAll(jsonPkgFile)
+	if err != nil {
+		util.Display(
+			os.Stderr, true,
+			"rpkgm couldn't read the json file's content. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// Initialize the Packages struct
+	var pkgs database.Packages
+
+	// Read the json content of the file
+	err = json.Unmarshal(contentInbytes, &pkgs)
+	if err != nil {
+		util.Display(os.Stderr, true, "rpkgm couldn't read the json file. Error: %s", err)
+		os.Exit(1)
+	}
+
+	// for every package in the json file, add it to the repo
+	for index := 0; index < len(pkgs.Packages); index++ {
+		// If there isn't a description, give one by default
+		if pkgs.Packages[index].Description == "" {
+			pkgs.Packages[index].Description = "[No description provided for this package.]"
+		}
+
+		// If there isn't a build files dir, give one by default
+		if pkgs.Packages[index].BuildFilesDir == "" {
+			pkgs.Packages[index].BuildFilesDir = fmt.Sprintf(
+				"var/rpkgm/main/%s",
+				pkgs.Packages[index].Name,
+			)
+		}
+
+		// Remove any trailing /
+		pkgs.Packages[index].BuildFilesDir = strings.TrimSuffix(
+			pkgs.Packages[index].BuildFilesDir,
+			"/",
+		)
+
+		// Add the package to the repo
+		err = dbAdapter.AddToRepo(
+			pkgs.Packages[index].Name,
+			pkgs.Packages[index].Description,
+			pkgs.Packages[index].Version,
+			pkgs.Packages[index].BuildFilesDir,
+		)
+		if err != nil {
+			util.Display(
+				os.Stderr, true,
+				"rpkgm was unable to add %s to the repo. Error: %s",
+				pkgs.Packages[index].Name,
+				err,
+			)
+		}
+	}
+
+	// Close the json file
+	err = jsonPkgFile.Close()
+	if err != nil {
+		util.Display(os.Stderr, true, "rpgkm couln't close the json file. Error: %s", err)
+		os.Exit(1)
+	}
+}
+
+// addPkg adds a packages with its general information to a repo.
+func addPkg(name, description, version, buildFilesDir string, dbAdapter *database.Adapter) {
+	// Default value for buildFilesDir (doing it here instead of Flags() because I need 'name')
+	if buildFilesDir == "" {
+		buildFilesDir = fmt.Sprintf("var/rpkgm/main/%s", name)
+	}
+
+	// Remove any trailing /
+	buildFilesDir = strings.TrimSuffix(buildFilesDir, "/")
+
+	// Add the package to the main repo
+	err := dbAdapter.AddToRepo(name, description, version, buildFilesDir)
+	if err != nil {
+		util.Display(
+			os.Stderr, true,
+			"rpkgm could not add the package %s to the repo. Error: %s",
+			name, err,
+		)
+		os.Exit(1)
+	}
+}
+
+// Decide decides what to do based on the given strings.
+func Decide(repoDB, name, description, version, buildFilesDir, importFile string) {
+	// Connect to the database
+	dbAdapter, err := database.NewAdapter("sqlite3", repoDB)
+	if err != nil {
+		util.Display(os.Stderr, true, "rpkgm could not connect to the database. Error: %s", err)
+		os.Exit(1)
+	}
+
+	// Create the packages table if it does not exist
+	err = dbAdapter.CreatePkgTable()
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not create the packages table in the repo. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// import a file to the repo
+	if importFile != "" {
+		ImportPkgs(importFile, dbAdapter)
+	}
+
+	// add a package to the repo
+	if name != "" && version != "" {
+		addPkg(name, description, version, buildFilesDir, dbAdapter)
+	}
+
+	// Close the database connection
+	err = dbAdapter.CloseDBConnection()
+	if err != nil {
+		util.Display(
+			os.Stderr, true,
+			"rpkgm could not close the connection to the database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+}

--- a/internal/logging/log.go
+++ b/internal/logging/log.go
@@ -14,7 +14,7 @@ func LogToFile(format string, toLog ...any) {
 	// Open the log file or create it if it does not exist
 	logFile, err := os.OpenFile("var/log/rpkgm.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, fileMode)
 	if err != nil {
-		log.Println("rpkgm could not open the log file.")
+		log.Printf("rpkgm could not open the log file. Error: %s\n", err)
 
 		return
 	}
@@ -28,7 +28,7 @@ func LogToFile(format string, toLog ...any) {
 	// Close the log file
 	err = logFile.Close()
 	if err != nil {
-		log.Println("rpkgm could not close the log file.")
+		log.Printf("rpkgm could not close the log file. Error: %s\n", err)
 
 		return
 	}

--- a/internal/manage/manage.go
+++ b/internal/manage/manage.go
@@ -1,0 +1,196 @@
+package manage
+
+import (
+	"os"
+
+	"github.com/redds-be/rpkgm/internal/database"
+	"github.com/redds-be/rpkgm/internal/util"
+)
+
+// remove removes a package.
+func remove(name string, dbAdapter *database.Adapter) {
+	err := dbAdapter.RemovePackage(name)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not delete the package from the repository. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// Close the database connection
+	err = dbAdapter.CloseDBConnection()
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not close the connection to the database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+// changeDesc changes the description of a package.
+func changeDesc(name, newDesc string, dbAdapter *database.Adapter) {
+	err := dbAdapter.ChangePkgDesc(name, newDesc)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not change the package's description in the repo's database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+}
+
+// markAsInstalled marks a package as installed.
+func markAsInstalled(name string, dbAdapter *database.Adapter) {
+	err := dbAdapter.MarkAsInstalled(name)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not mark the package as installed in the repo's database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+}
+
+// markAsNotInstalled marks a package as not installed.
+func markAsNotInstalled(name string, dbAdapter *database.Adapter) {
+	err := dbAdapter.MarkAsNotInstalled(name)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not mark the package as not installed in the repo's database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+}
+
+// changeInstalledVersion changes the installed version of a package.
+func changeInstalledVersion(name, installedVersion string, dbAdapter *database.Adapter) {
+	err := dbAdapter.SetInstalledVersion(name, installedVersion)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not set the package's installed version. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+}
+
+// changeRepoVersion changes the repo version of package.
+func changeRepoVersion(name, repoVersion string, dbAdapter *database.Adapter) {
+	err := dbAdapter.UpdateRepoVersion(name, repoVersion)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not set the package's repo version. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+}
+
+// rename renames a package.
+func rename(name, newName string, dbAdapter *database.Adapter) {
+	err := dbAdapter.RenamePackage(name, newName)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not rename the package in the repo's database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+}
+
+// Decide decies what to do based on the given booleans.
+func Decide( //nolint:funlen,cyclop
+	repoDB, name, newName, newDesc, installedVersion, repoVersion string,
+	doRemove, markInstalled, markNotInstalled bool,
+) {
+	// Connect to the database
+	dbAdapter, err := database.NewAdapter("sqlite3", repoDB)
+	if err != nil {
+		util.Display(os.Stderr, true, "rpkgm could not connect to the database. Error: %s", err)
+		os.Exit(1)
+	}
+
+	// Check if the given package is in the repo (forcing the close of the db connection since it's not a fatal error)
+	isInRepo, _ := dbAdapter.IsPkgInRepo(name)
+	if !isInRepo {
+		util.Display(os.Stderr, true, "The package: %s is not in the repository.", name)
+
+		// Close the database connection
+		err := dbAdapter.CloseDBConnection()
+		if err != nil {
+			util.Display(
+				os.Stderr,
+				true,
+				"rpkgm could not close the connection to the database. Error: %s",
+				err,
+			)
+			os.Exit(1)
+		}
+		os.Exit(1)
+	}
+
+	// Remove the package
+	if doRemove {
+		remove(name, dbAdapter)
+	}
+
+	// Change the package's description
+	if newDesc != "" {
+		changeDesc(name, newDesc, dbAdapter)
+	}
+
+	// Mark the package as installed or as not installed
+	if markInstalled {
+		markAsInstalled(name, dbAdapter)
+	} else if markNotInstalled {
+		markAsNotInstalled(name, dbAdapter)
+	}
+
+	// Change or set the package's installed version
+	if installedVersion != "" {
+		changeInstalledVersion(name, installedVersion, dbAdapter)
+	}
+
+	// Change the package's repo version
+	if repoVersion != "" {
+		changeRepoVersion(name, repoVersion, dbAdapter)
+	}
+
+	// Rename the package
+	if newName != "" {
+		rename(name, newName, dbAdapter)
+	}
+
+	// Close the database connection
+	err = dbAdapter.CloseDBConnection()
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not close the connection to the database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+}

--- a/internal/show/show.go
+++ b/internal/show/show.go
@@ -1,0 +1,164 @@
+package show
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/redds-be/rpkgm/internal/database"
+	"github.com/redds-be/rpkgm/internal/util"
+)
+
+// printLicense prints the license of a given package assuming the license if in the build files.
+func printLicense(name string, dbAdapter *database.Adapter) {
+	// Find the build files for the given package, the license should be in there
+	buildFilesDir, err := dbAdapter.GetPkgBuildFilesDir(name)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not find the build files (build files includes the license) for the given package. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// Open the license file
+	licenseFile, err := os.Open(fmt.Sprintf("%s/LICENSE", buildFilesDir))
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not open or find the license file for the given package. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// Read the license file
+	licenseContent, err := io.ReadAll(licenseFile)
+	if err != nil {
+		util.Display(
+			os.Stderr, true,
+			"rpkgm could not read from the license file of the given package. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// Print the license file's content
+	util.Display(os.Stdout, false, "%v", string(licenseContent))
+
+	// Close the license file
+	err = licenseFile.Close()
+	if err != nil {
+		util.Display(
+			os.Stderr, true,
+			"rpkgm could not close the license file for the given package. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+}
+
+// printInfo prints the general information of a given package.
+func printInfo(name string, dbAdapter *database.Adapter) {
+	// Get the given package's general info
+	pkgInfo, err := dbAdapter.GetPkgInfo(name)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not get the given package's information. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// Display the general info (changes depending on the installation status)
+	if pkgInfo.Installed {
+		util.Display(
+			os.Stdout, false,
+			"%s [Installed (%s)]\t- %s\t- Repo's version: %s",
+			pkgInfo.Name,
+			pkgInfo.InstalledVersion,
+			pkgInfo.Description,
+			pkgInfo.RepoVersion,
+		)
+	} else {
+		util.Display(os.Stdout, false, "%s [Not installed]\t- %s\t- Repo's version: %s", pkgInfo.Name, pkgInfo.Description, pkgInfo.RepoVersion)
+	}
+}
+
+// printAllinfo prints the general information of every package in the repo.
+func printAllinfo(dbAdapter *database.Adapter) {
+	// Get every package info in the database
+	allPkgInfo, err := dbAdapter.GetAllPkgInfo()
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could query the repo's database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// For every package, display the info (changes depending on the installation status)
+	for _, pkgInfo := range allPkgInfo {
+		if pkgInfo.Installed {
+			util.Display(
+				os.Stdout, false,
+				"%s [Installed (%s)]\t- %s\t- Repo's version: %s",
+				pkgInfo.Name,
+				pkgInfo.InstalledVersion,
+				pkgInfo.Description,
+				pkgInfo.RepoVersion,
+			)
+		} else {
+			util.Display(os.Stdout, false, "%s [Not installed]\t- %s\t- Repo's version: %s", pkgInfo.Name, pkgInfo.Description, pkgInfo.RepoVersion)
+		}
+	}
+}
+
+// Decide decies what to do based on the given booleans.
+func Decide(repoDB, name string, showLicense, showInfo, showAll bool) {
+	// Connect to the database
+	dbAdapter, err := database.NewAdapter("sqlite3", repoDB)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could connect to the repo's database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// Show the license of the package
+	if showLicense {
+		printLicense(name, dbAdapter)
+	}
+
+	// Show the general info of the package
+	if showInfo {
+		printInfo(name, dbAdapter)
+	}
+
+	// Show the general info of all the packages
+	if showAll {
+		printAllinfo(dbAdapter)
+	}
+
+	// Close the database connection
+	err = dbAdapter.CloseDBConnection()
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not close the connection to the database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1,0 +1,210 @@
+package sync
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/redds-be/rpkgm/internal/add"
+	"github.com/redds-be/rpkgm/internal/database"
+	"github.com/redds-be/rpkgm/internal/util"
+)
+
+// dlFromRemote downloads the repo's JSON file and the packages build files from a remote.
+func dlFromRemote(remote, repoName string) string {
+	destDir := fmt.Sprintf("var/rpkgm/%s", repoName)
+
+	err := os.MkdirAll(destDir, os.ModePerm)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not create the destination directory for the build files.",
+		)
+		os.Exit(1)
+	}
+
+	archive := fmt.Sprintf("var/rpkgm/%s/%s.tar.gz", repoName, repoName)
+
+	err = util.Download(
+		archive,
+		fmt.Sprintf("https://%s/raw/main/%s.tar.gz", remote, repoName),
+	)
+	if err != nil {
+		util.Display(os.Stderr, true, "rpkgm could not download the build files.")
+		os.Exit(1)
+	}
+
+	importFile := fmt.Sprintf("var/rpkgm/%s/repo.json", repoName)
+
+	err = util.Download(
+		importFile,
+		fmt.Sprintf("https://%s/raw/main/repo.json", remote),
+	)
+	if err != nil {
+		util.Display(os.Stderr, true, "rpkgm could not download the JSON file of the repo.")
+		os.Exit(1)
+	}
+
+	err = util.Untar(destDir, archive)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not untar the repo's archive. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	return importFile
+}
+
+// syncWithFile syncs a repo using a file.
+func syncWithFile(importFile string, dbAdapter *database.Adapter) { //nolint:funlen,cyclop
+	// Open the file to import
+	jsonPkgFile, err := os.Open(importFile)
+	if err != nil {
+		util.Display(os.Stderr, true, "rpkgm couldn't open the json file. Error: %s", err)
+		os.Exit(1)
+	}
+
+	// Read the file's content
+	contentInbytes, err := io.ReadAll(jsonPkgFile)
+	if err != nil {
+		util.Display(
+			os.Stderr, true,
+			"rpkgm couldn't read the json file's content. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// Initialize the Packages struct
+	var pkgs database.Packages
+
+	// Read the json content of the file
+	err = json.Unmarshal(contentInbytes, &pkgs)
+	if err != nil {
+		util.Display(os.Stderr, true, "rpkgm couldn't read the json file. Error: %s", err)
+		os.Exit(1)
+	}
+
+	// for every package in the json file, update their record
+	for index := 0; index < len(pkgs.Packages); index++ {
+		// Since UPDATE will set null strings as null in the database,
+		// we need to get the old information to avoid deleting some information if the JSON field is null.
+		pkgInfo, err := dbAdapter.GetPkgInfo(pkgs.Packages[index].Name)
+		if err != nil {
+			util.Display(
+				os.Stderr,
+				true,
+				"rpkgm was unable to get the information for the package %s to compare against new information. Error: %s",
+				pkgs.Packages[index].Name,
+				err,
+			)
+
+			continue
+		}
+
+		// If there isn't a description, give one by default
+		if pkgs.Packages[index].Description == "" {
+			pkgs.Packages[index].Description = pkgInfo.Description
+		}
+
+		// If there isn't a build files dir, give one by default
+		if pkgs.Packages[index].BuildFilesDir == "" {
+			pkgs.Packages[index].BuildFilesDir = pkgInfo.BuildFilesDir
+		}
+
+		// Remove any trailing /
+		pkgs.Packages[index].BuildFilesDir = strings.TrimSuffix(
+			pkgs.Packages[index].BuildFilesDir,
+			"/",
+		)
+
+		if pkgs.Packages[index].Version == "" {
+			pkgs.Packages[index].Version = pkgInfo.RepoVersion
+		}
+
+		// Add the package to the repo
+		err = dbAdapter.SyncRepo(
+			pkgs.Packages[index].Name,
+			pkgs.Packages[index].Description,
+			pkgs.Packages[index].Version,
+			pkgs.Packages[index].BuildFilesDir,
+		)
+		if err != nil {
+			util.Display(
+				os.Stderr, true,
+				"rpkgm was unable to update %s in the repo. Error: %s",
+				pkgs.Packages[index].Name,
+				err,
+			)
+		}
+	}
+
+	// Close the json file
+	err = jsonPkgFile.Close()
+	if err != nil {
+		util.Display(os.Stderr, true, "rpgkm couln't close the json file. Error: %s", err)
+		os.Exit(1)
+	}
+}
+
+// Decide decides what to do based on the given strings.
+func Decide(repoDB, importFile, remote, repoName string) {
+	if importFile == "" {
+		importFile = dlFromRemote(remote, repoName)
+	}
+
+	var doAdd bool
+
+	if _, err := os.Stat(repoDB); errors.Is(err, os.ErrNotExist) {
+		doAdd = true
+	}
+
+	// Connect to the database
+	dbAdapter, err := database.NewAdapter("sqlite3", repoDB)
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not connect to the database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// Create the packages table if it does not exist
+	err = dbAdapter.CreatePkgTable()
+	if err != nil {
+		util.Display(
+			os.Stderr,
+			true,
+			"rpkgm could not create the packages table in the repo. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	if doAdd {
+		add.ImportPkgs(importFile, dbAdapter)
+	} else {
+		syncWithFile(importFile, dbAdapter)
+	}
+
+	// Close the database connection
+	err = dbAdapter.CloseDBConnection()
+	if err != nil {
+		util.Display(
+			os.Stderr, true,
+			"rpkgm could not close the connection to the database. Error: %s",
+			err,
+		)
+		os.Exit(1)
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -41,7 +41,7 @@ var (
 func CheckRoot() {
 	currUser, err := user.Current()
 	if err != nil {
-		Display(os.Stderr, true, "Unable to determine if rpkgm is running as root.")
+		Display(os.Stderr, true, "Unable to determine if rpkgm is running as root. Error: %s", err)
 		os.Exit(1)
 	}
 
@@ -55,7 +55,7 @@ func CheckRoot() {
 func Display(out io.Writer, doLog bool, format string, toDisplay ...any) {
 	_, err := fmt.Fprintf(out, fmt.Sprintf("%s\n", format), toDisplay...)
 	if err != nil {
-		log.Println("rpkgm was unable to print output...")
+		log.Printf("rpkgm was unable to print to output. Error: %s\n", err)
 	}
 
 	if doLog {


### PR DESCRIPTION
The logic used in subcommands were separated into their own packages, for each, there's a Decide() function that determines what to do (checking the values of string and booleans), connects to the database, then perform the actions of the subcommands.

The logic is copy-pasted from the original one but separated into functions for the main actions that are called by the Decide() function. Nothing really changed apart from adding the removal of trailing slashes for the buildFilesDir.